### PR TITLE
netbox-base.yml: use GIT_REMOTE instead of GIT_REPO

### DIFF
--- a/openshift/netbox-base.yaml
+++ b/openshift/netbox-base.yaml
@@ -46,7 +46,7 @@ objects:
       contextDir: openshift
       git:
         ref: ${GIT_REF}
-        uri: ${GIT_REPO}
+        uri: ${GIT_REMOTE}
       type: Git
     strategy:
       dockerStrategy:


### PR DESCRIPTION
`GIT_REPO` isn't defined anywhere, and makes the build failed. Changing it to
`GIT_REMOTE` (which *is* defined) appears to work fine, however.