### PR TITLE
Use a static database username ('netbox') by default

### DIFF
--- a/openshift/netbox.yaml
+++ b/openshift/netbox.yaml
@@ -32,8 +32,7 @@ parameters:
   name: DJANGO_SECRET_KEY
 - description: Username for PostgreSQL user that will be used for accessing the database.
   displayName: PostgreSQL Connection Username
-  from: user[A-Z0-9]{3}
-  generate: expression
+  value: netbox
   name: POSTGRESQL_USER
   required: true
 - description: Password for the PostgreSQL connection user.


### PR DESCRIPTION
This ensures that a database dump/backup taken before tearing down the
application can be restored after the application is rebuilt from scratch,
without the restore process giving lots of errors like these:

```
pg_restore: [archiver (db)] Error from TOC entry 371; 1259 24372 SEQUENCE virtualization_virtualmachine_id_seq userOBT
pg_restore: [archiver (db)] could not execute query: ERROR:  role "userOBT" does not exist
    Command was: ALTER TABLE virtualization_virtualmachine_id_seq OWNER TO "userOBT";
```

(This happens with the current code because the database username is randomly
generated and will change between redeployments.)