### PR TITLE
WIP: Update to NetBox v2.5.13

### DIFF
--- a/openshift/netbox.yaml
+++ b/openshift/netbox.yaml
@@ -21,7 +21,7 @@ parameters:
 - displayName: Git Reference
   name: GIT_REF
   required: true
-  value: v2.5.12
+  value: v2.5.13
 - displayName: Public FQDN
   name: FQDN
   required: true

--- a/openshift/s2i/assemble.sh
+++ b/openshift/s2i/assemble.sh
@@ -23,34 +23,4 @@ cp /opt/app-root/etc/openshift_urls.py netbox/netbox/openshift_urls.py
 cp /opt/app-root/etc/openshift_middleware.py netbox/netbox/openshift_middleware.py
 cp /opt/app-root/etc/openshift_auth.py netbox/netbox/openshift_auth.py
 
-# Revert commit that breaks 3rd party authentication
-patch -R -p1 <<EOF
-From 6f5c35c2781a1dab157313b1ef87de2ae8de92be Mon Sep 17 00:00:00 2001
-From: Jeremy Stretch <jstretch@digitalocean.com>
-Date: Thu, 28 Feb 2019 11:40:32 -0500
-Subject: [PATCH] Force resolution of request User object when logging an
- object deletion (resolves intermittent test failures)
-
----
- netbox/extras/middleware.py | 6 +++++-
- 1 file changed, 5 insertions(+), 1 deletion(-)
-
-diff --git a/netbox/extras/middleware.py b/netbox/extras/middleware.py
-index 16461c32a..38dde6275 100644
---- a/netbox/extras/middleware.py
-+++ b/netbox/extras/middleware.py
-@@ -29,7 +29,11 @@ def cache_changed_object(instance, **kwargs):
-
- def _record_object_deleted(request, instance, **kwargs):
-
--    # Record that the object was deleted.
-+    # Force resolution of request.user in case it's still a SimpleLazyObject. This seems to happen
-+    # occasionally during tests, but haven't been able to determine why.
-+    assert request.user.is_authenticated
-+
-+    # Record that the object was deleted
-     if hasattr(instance, 'log_change'):
-         instance.log_change(request.user, request.id, OBJECTCHANGE_ACTION_DELETE)
-EOF
-
 fix-permissions /opt/app-root


### PR DESCRIPTION
Due to digitalocean/netbox@1e1aba73 incorporated in this release, it no longer
necessary to revert digitalocean/netbox@6f5c35c2 in
`openshift/s2i/assemble.sh`.

Note: this a work in progress pull request, it doesn't yet work: the NetBox container fails to start (backtrace quoted below). I'll try to investigate this further later on, but I thought I'd submit the PR anyway, in case you can spot the problem right away.

```
---> Migrating database ...
Traceback (most recent call last):
  File "./manage.py", line 10, in <module>
    execute_from_command_line(sys.argv)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/__init__.py", line 381, in execute_from_command_line
    utility.execute()
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/__init__.py", line 375, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/base.py", line 323, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/base.py", line 361, in execute
    self.check()
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/base.py", line 390, in check
    include_deployment_checks=include_deployment_checks,
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/commands/migrate.py", line 65, in _run_checks
    issues.extend(super()._run_checks(**kwargs))
  File "/opt/app-root/lib/python3.6/site-packages/django/core/management/base.py", line 377, in _run_checks
    return checks.run_checks(**kwargs)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/checks/registry.py", line 72, in run_checks
    new_errors = check(app_configs=app_configs)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/checks/urls.py", line 13, in check_url_config
    return check_resolver(resolver)
  File "/opt/app-root/lib/python3.6/site-packages/django/core/checks/urls.py", line 23, in check_resolver
    return check_method()
  File "/opt/app-root/lib/python3.6/site-packages/django/urls/resolvers.py", line 398, in check
    for pattern in self.url_patterns:
  File "/opt/app-root/lib/python3.6/site-packages/django/utils/functional.py", line 80, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/app-root/lib/python3.6/site-packages/django/urls/resolvers.py", line 579, in url_patterns
    patterns = getattr(self.urlconf_module, "urlpatterns", self.urlconf_module)
  File "/opt/app-root/lib/python3.6/site-packages/django/utils/functional.py", line 80, in __get__
    res = instance.__dict__[self.name] = self.func(instance)
  File "/opt/app-root/lib/python3.6/site-packages/django/urls/resolvers.py", line 572, in urlconf_module
    return import_module(self.urlconf_name)
  File "/opt/app-root/lib64/python3.6/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 994, in _gcd_import
  File "<frozen importlib._bootstrap>", line 971, in _find_and_load
  File "<frozen importlib._bootstrap>", line 955, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 665, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 678, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/opt/app-root/src/netbox/netbox/openshift_urls.py", line 10, in <module>
    ] + urlpatterns + [
NameError: name 'url' is not defined
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leoluk/openshift-netbox/13)
<!-- Reviewable:end -->
